### PR TITLE
Ordered counties before rendering in search by county or location

### DIFF
--- a/src/assets/js/maps_mep.js
+++ b/src/assets/js/maps_mep.js
@@ -269,7 +269,12 @@ function setCountySelector(features) {
   var id_key = "counties"
   var text = "<div class='col-sm-12'><label class='map-filter-label'>Search by county or location:<small>(<a href='#' id='clearcounty'>clear</a>)</small></label>"
   text += "<select class='map-filter' id='" + id_key + "' name='" + id_key + "[]'>"
-  for (var [code, values] of Object.entries(county_map)) {
+  // Order the items before rendering
+  let ordered_items = Object.entries(county_map).sort(
+    (a, b) => (a[1].name.localeCompare(b[1].name))
+  )
+  // Generate the option strings
+  for (var [code, values] of ordered_items) {
     text += "<option value='" + code + "'>" + values['name'] + "</option>"
   }
   text += "</select></div>"

--- a/src/assets/js/maps_mep.js
+++ b/src/assets/js/maps_mep.js
@@ -229,10 +229,12 @@ function setFeatureProperties(feature, mep_location_map, set_global=false) {
     }
     return null;
   }
+
   // Add this to the global list of regions
-  if (set_global) {
-    region_features.push(feature)
-  }
+  //if (set_global) {
+  //  region_features.push(feature)
+  //}
+
   console.log("Setting properties for region", regionLevel, regionName)
   feature.setProperty('regionLevel', regionLevel)
   feature.setProperty('regionName', regionName)
@@ -248,6 +250,11 @@ function setFeatureProperties(feature, mep_location_map, set_global=false) {
 
 function setFeaturePropertiesAndStyles(features, mep_location_map, set_global=false) {
   for (var feature of features) {
+    // Add this to the global list of regions
+    if (set_global) {
+      region_features.push(feature)
+    }
+    // Set the features and properties for this
     setFeatureProperties(feature, mep_location_map, set_global)
   }
 }


### PR DESCRIPTION
@ImogenPlayer1 I have updated to fix the first point in your email: "_The dropdown on “Search by county or location” should be in alphabetical order to make searching easier – the council search does this already_ "

I am looking at the other issues but they seem to be related to Edge browsers only.